### PR TITLE
fix: prefer `nitro.static` over `_generate`

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -71,7 +71,7 @@ export function getDefineConfig({ options, fullStatic }: I18nNuxtContext, server
 
   const common = {
     __IS_SSR__: String(nuxt.options.ssr),
-    __IS_SSG__: String(nuxt.options._generate),
+    __IS_SSG__: String(nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */),
     __PARALLEL_PLUGIN__: String(options.parallelPlugin),
     __DYNAMIC_PARAMS_KEY__: JSON.stringify(DYNAMIC_PARAMS_KEY),
     __DEFAULT_COOKIE_KEY__: JSON.stringify(DEFAULT_COOKIE_KEY),

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -70,7 +70,7 @@ export async function setupPages({ localeCodes, options, normalizedLocales }: I1
 
       // keep root when using prefixed routing without prerendering
       const indexPage = pages.find(x => x.path === '/')
-      if (!nuxt.options._generate && options.strategy === 'prefix' && indexPage != null) {
+      if (!nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */ && options.strategy === 'prefix' && indexPage != null) {
         localizedPages.unshift(indexPage as NarrowedNuxtPage)
       }
 

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -70,7 +70,7 @@ export async function setupPages({ localeCodes, options, normalizedLocales }: I1
 
       // keep root when using prefixed routing without prerendering
       const indexPage = pages.find(x => x.path === '/')
-      if (!nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */ && options.strategy === 'prefix' && indexPage != null) {
+      if (!(nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */) && options.strategy === 'prefix' && indexPage != null) {
         localizedPages.unshift(indexPage as NarrowedNuxtPage)
       }
 

--- a/src/prepare/strategy.ts
+++ b/src/prepare/strategy.ts
@@ -2,7 +2,7 @@ import type { I18nNuxtContext } from '../context'
 import type { Nuxt } from '@nuxt/schema'
 
 export function prepareStrategy({ options, localeCodes }: I18nNuxtContext, nuxt: Nuxt) {
-  if (options.strategy === 'prefix' && nuxt.options._generate) {
+  if (options.strategy === 'prefix' && nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */) {
     const localizedEntryPages = localeCodes.map(x => '/' + x)
     nuxt.hook('nitro:config', config => {
       config.prerender ??= {}

--- a/src/prepare/strategy.ts
+++ b/src/prepare/strategy.ts
@@ -2,7 +2,7 @@ import type { I18nNuxtContext } from '../context'
 import type { Nuxt } from '@nuxt/schema'
 
 export function prepareStrategy({ options, localeCodes }: I18nNuxtContext, nuxt: Nuxt) {
-  if (options.strategy === 'prefix' && nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */) {
+  if (options.strategy === 'prefix' && (nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */)) {
     const localizedEntryPages = localeCodes.map(x => '/' + x)
     nuxt.hook('nitro:config', config => {
       config.prerender ??= {}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Since nuxi v3.8, we've supported setting `nuxt.options.nitro.static` instead of `nuxt.options._generate` (which is an internal flag) - see https://github.com/nuxt/nuxt/pull/21860.

Now, in preparation for Nuxt v4, we've removed the types for `_generate` (see https://github.com/nuxt/nuxt/pull/32355). This PR adds support for new version in backwards compatible way (ignoring type issues) - I'd suggest you remove support in a future major.